### PR TITLE
Fix nslookup arguments

### DIFF
--- a/src/SA/nslookup/extension.json
+++ b/src/SA/nslookup/extension.json
@@ -29,10 +29,16 @@
             "optional": false
         },
         {
+            "name": "server",
+            "desc": "DNS Server to use",
+            "type": "string",
+            "optional": false
+        },
+        {
             "name": "type",
             "desc": "DNS record type (A, AAAA, or ANY), see https://docs.microsoft.com/en-us/windows/win32/dns/dns-constants for the actual values",
             "type": "short",
-            "optional": true
+            "optional": false
         }
     ]
 }


### PR DESCRIPTION
Fix nslookup BOF arguments. Since we can't have a mandatory argument positioned after an optional argument, I made the `server` argument mandatory, it just can take an empty value:

```shell
[server] sliver (CLEAR_ORATOR) > sa-nslookup google.com "" 1
```