### PR TITLE
Fix wmi_query help text

### DIFF
--- a/src/SA/wmi_query/extension.json
+++ b/src/SA/wmi_query/extension.json
@@ -5,7 +5,7 @@
     "extension_author": "moloch--",
     "original_author": "TrustedSec",
     "repo_url": "https://github.com/sliverarmory/CS-Situational-Awareness-BOF",
-    "help": "Lists visible windows in the current users session",
+    "help": "Run a wmi query and display results in CSV format",
     "long_help": "",
     "depends_on": "coff-loader",
     "entrypoint": "go",


### PR DESCRIPTION
The help text for the `wmi_query` command is the description for the `windowlist` command. This PR fixes the help text to match the README.md table description.