### PR TITLE
Update ldapsearch to support ldaps

### DIFF
--- a/src/SA/ldapsearch/extension.json
+++ b/src/SA/ldapsearch/extension.json
@@ -1,55 +1,68 @@
 {
-    "name": "LDAP Search (SA)",
-    "version": "0.0.0",
-    "command_name": "sa-ldapsearch",
-    "extension_author": "moloch--",
-    "original_author": "TrustedSec",
-    "repo_url": "https://github.com/sliverarmory/CS-Situational-Awareness-BOF",
-    "help": "Executes LDAP searches",
-    "depends_on": "coff-loader",
-    "entrypoint": "go",
-    "files": [
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "path": "ldapsearch.x64.o"
-        },
-        {
-            "os": "windows",
-            "arch": "386",
-            "path": "ldapsearch.x86.o"
-        }
-    ],
-    "arguments": [
-        {
-            "name": "query",
-            "desc": "Query",
-            "type": "string",
-            "optional": false
-        },
-        {
-            "name": "attributes",
-            "desc": "Comma separated attributes",
-            "type": "string",
-            "optional": true
-        },
-        {
-            "name": "results_count",
-            "desc": "Limit number of results",
-            "type": "integer",
-            "optional": true
-        },
-        {
-            "name": "hostname",
-            "desc": "DC hostname or IP",
-            "type": "string",
-            "optional": true
-        },
-        {
-            "name": "dn",
-            "desc": "Distingished Name to use",
-            "type": "string",
-            "optional": true
-        }
-    ]
+  "name": "ldapsearch",
+  "version": "0.0.0",
+  "command_name": "sa-ldapsearch",
+  "extension_author": "c2biz",
+  "original_author": "TrustedSec",
+  "repo_url": "https://github.com/sliverarmory/CS-Situational-Awareness-BOF",
+  "help": "Execute LDAP searches",
+  "long_help": "This command allows users to perform LDAP search operations against specified directories, enabling enumeration of users, groups, and other objects in an Active Directory environment.",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "ldapsearch.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "ldapsearch.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "ldap_filter",
+      "desc": "Query to filter LDAP entries.",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "ldap_attributes",
+      "desc": "Specific attributes to retrieve from LDAP entries.",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "results_count",
+      "desc": "Limit on the number of results to return.",
+      "type": "integer",
+      "optional": true
+    },
+    {
+      "name": "scope",
+      "desc": "Scope of the search.",
+      "type": "integer",
+      "optional": true
+    },
+    {
+      "name": "hostname",
+      "desc": "Hostname or IP address of the Domain Controller.",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "domain",
+      "desc": "Distinguished Name (DN) to use for the query base.",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "ldaps",
+      "desc": "Use LDAPS for the connection (1 for true, 0 for false).",
+      "type": "integer",
+      "optional": true
+    }
+  ]
 }


### PR DESCRIPTION
Hello!

I found out that Sliver armory pulls the nonpagedldapsearch BOF by default which is 5 years old & no longer being updated, this is a problem because newer features are not included.

Latest version of `ldapsearch` BOF includes:

- Support for LDAPS.
- Support for pulling the `nTSecurityDescriptor` attribute, which is important if we want to analyze ACL security & attack paths.

I have tested my changes, substituting `nonpagedldapsearch` for the regular ldapsearch BOF & my `extension.json` in my home lab by loading the extension manually via `extension load` & running a few queries.

❗ **One important issue which makes some queries fail**:

Argument "scope" needs to be set 3 as default value, not sure how to do that in the extensions file since I couldn't find documentation for all the valid fields.

Hopefully these changes can be included & the default `sa-ldapsearch` changed from nonpaged to regular.

Thanks & have a great day! :)